### PR TITLE
Update main.css

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -97,6 +97,7 @@ a:hover {
 pre {
   margin: 15px 0;
   font-family: Consolas, "Liberation Mono", Courier, monospace;
+  overflow-x:auto;
 }
 code {
   font-family: Consolas, "Liberation Mono", Courier, monospace;


### PR DESCRIPTION
When over long lines in `<pre>`, show a scrollbar.
eg: these lines in [http://quickdocs.org/chirp/](http://quickdocs.org/chirp/)

```lisp
(chirp:compute-status-length "Wowsers, URL shortening sure is a thing! https://github.com/Shinmera/chirp.git")
(chirp:valid-language-p "en")
(chirp:access-level)
```


before this line, it go pass the right margin of the pre block. This change in css will automatically shows a scrollbar when this happens, this is what github's markdown display do with block of code.